### PR TITLE
Fix Julian Date calculation for January and February

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "solar-calc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A sunrise/sunset/moonrise/moonset calculator",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "compile": "npm run clean && ./node_modules/.bin/babel src --out-dir lib",
-    "prepublish": "npm run compile",
-    "test": "npm run compile && ./node_modules/.bin/mocha",
-    "lint": "./node_modules/.bin/eslint src",
+    "build": "babel src --out-dir lib",
+    "prepublish": "npm run build",
+    "test": "npm run build && mocha",
+    "lint": "eslint src",
     "clean": "rm -rf lib"
   },
   "repository": {
@@ -30,10 +30,12 @@
   },
   "homepage": "https://github.com/jonhester/solar-calc",
   "devDependencies": {
-    "babel": "^4.7.8",
-    "babel-eslint": "^2.0.0",
-    "eslint": "^0.16.0",
-    "mocha": "^2.2.0"
+    "@babel/cli": "^7.13.0",
+    "@babel/core": "^7.13.8",
+    "@babel/preset-env": "^7.13.9",
+    "babel-eslint": "^10.1.0",
+    "eslint": "^7.21.0",
+    "mocha": "^8.3.0"
   },
   "dependencies": {}
 }

--- a/src/sun.js
+++ b/src/sun.js
@@ -180,6 +180,10 @@ function isNumber(inputVal) {
 function getJD(date) {
   var year = date.getFullYear();
   var month = date.getMonth() + 1;
+  if (month < 3) {
+    year--;
+    month += 12;
+  }
   var day = date.getDate();
 
   var A = Math.floor(year / 100);

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,17 @@ var SolarCalc = require('../'); // our module
 
 describe('suncalc', function() {
   
+  describe('2021-02-14 in Paris', function() {
+    it('get sunset', function() {
+      var solarCalc = new SolarCalc(
+        new Date(2021, 1, 14),
+        48.85341,
+        2.3488
+      );
+      assert.strictEqual(1613322598000, solarCalc.sunset.getTime());
+    });
+  });
+
   describe('2015-03-08 in North Carolina', function() {
     var solarCalc;
 
@@ -17,63 +28,63 @@ describe('suncalc', function() {
     });
 
     it('get solar noon', function() {
-      assert.equal(1425835523000, solarCalc.solarNoon.getTime());
+      assert.strictEqual(1425835523000, solarCalc.solarNoon.getTime());
     });
 
     it('get golden hour start', function() {
-      assert.equal(1425854506000, solarCalc.goldenHourStart.getTime());
+      assert.strictEqual(1425854506000, solarCalc.goldenHourStart.getTime());
     });
 
      it('get golden hour end', function() {
-      assert.equal(1425816570000, solarCalc.goldenHourEnd.getTime());
+      assert.strictEqual(1425816570000, solarCalc.goldenHourEnd.getTime());
     });
 
     it('get night end', function() {
-      assert.equal(1425809446000, solarCalc.nightEnd.getTime());
+      assert.strictEqual(1425809446000, solarCalc.nightEnd.getTime());
     });
 
     it('get nautical dawn', function() {
-      assert.equal(1425811226000, solarCalc.nauticalDawn.getTime());
+      assert.strictEqual(1425811226000, solarCalc.nauticalDawn.getTime());
     });
 
     it('get dawn', function() {
-      assert.equal(1425813000000, solarCalc.dawn.getTime());
+      assert.strictEqual(1425813000000, solarCalc.dawn.getTime());
     });
 
     it('get sunrise', function() {
-      assert.equal(1425814530000, solarCalc.sunrise.getTime());
+      assert.strictEqual(1425814530000, solarCalc.sunrise.getTime());
     });
 
     it('get sunriseEnd', function() {
-      assert.equal(1425814688000, solarCalc.sunriseEnd.getTime());
+      assert.strictEqual(1425814688000, solarCalc.sunriseEnd.getTime());
     });
 
     it('get sunsetStart', function() {
-      assert.equal(1425856389000, solarCalc.sunsetStart.getTime());
+      assert.strictEqual(1425856389000, solarCalc.sunsetStart.getTime());
     });
 
     it('get sunset', function() {
-      assert.equal(1425856548000, solarCalc.sunset.getTime());
+      assert.strictEqual(1425856548000, solarCalc.sunset.getTime());
     });
 
     it('get dusk', function() {
-      assert.equal(1425858080000, solarCalc.dusk.getTime());
+      assert.strictEqual(1425858080000, solarCalc.dusk.getTime());
     });
 
     it('get nautical dusk', function() {
-      assert.equal(1425859857000, solarCalc.nauticalDusk.getTime());
+      assert.strictEqual(1425859857000, solarCalc.nauticalDusk.getTime());
     });
 
     it('get night start', function() {
-      assert.equal(1425861641000, solarCalc.nightStart.getTime());
+      assert.strictEqual(1425861641000, solarCalc.nightStart.getTime());
     });
 
     it('should get moon illuminosity', function() {
-      assert.equal(83, Math.round(solarCalc.lunarIlluminosity * 100));
+      assert.strictEqual(83, Math.round(solarCalc.lunarIlluminosity * 100));
     });
 
     it('should get moon distance', function() {
-      assert.equal(384758, solarCalc.lunarDistance);
+      assert.strictEqual(384758, solarCalc.lunarDistance);
     });
 
   });
@@ -92,63 +103,63 @@ describe('suncalc', function() {
     });
 
     it('get solar noon', function() {
-      assert.equal(1435075933000, solarCalc.solarNoon.getTime());
+      assert.strictEqual(1435075933000, solarCalc.solarNoon.getTime());
     });
 
     it('get golden hour start', function() {
-      assert.equal(1439856000000, solarCalc.goldenHourStart.getTime());
+      assert.strictEqual(1439856000000, solarCalc.goldenHourStart.getTime());
     });
 
      it('get golden hour end', function() {
-      assert.equal(1430006400000, solarCalc.goldenHourEnd.getTime());
+      assert.strictEqual(1430006400000, solarCalc.goldenHourEnd.getTime());
     });
 
     it('get night end', function() {
-      assert.equal(1424476800000, solarCalc.nightEnd.getTime());
+      assert.strictEqual(1424476800000, solarCalc.nightEnd.getTime());
     });
 
     it('get nautical dawn', function() {
-      assert.equal(1425859200000, solarCalc.nauticalDawn.getTime());
+      assert.strictEqual(1425859200000, solarCalc.nauticalDawn.getTime());
     });
 
     it('get dawn', function() {
-      assert.equal(1427155200000, solarCalc.dawn.getTime());
+      assert.strictEqual(1427155200000, solarCalc.dawn.getTime());
     });
 
     it('get sunrise', function() {
-      assert.equal(1428364800000, solarCalc.sunrise.getTime());
+      assert.strictEqual(1428364800000, solarCalc.sunrise.getTime());
     });
 
     it('get sunriseEnd', function() {
-      assert.equal(1428451200000, solarCalc.sunriseEnd.getTime());
+      assert.strictEqual(1428451200000, solarCalc.sunriseEnd.getTime());
     });
 
     it('get sunsetStart', function() {
-      assert.equal(1441411200000, solarCalc.sunsetStart.getTime());
+      assert.strictEqual(1441411200000, solarCalc.sunsetStart.getTime());
     });
 
     it('get sunset', function() {
-      assert.equal(1441497600000, solarCalc.sunset.getTime());
+      assert.strictEqual(1441497600000, solarCalc.sunset.getTime());
     });
 
     it('get dusk', function() {
-      assert.equal(1442707200000, solarCalc.dusk.getTime());
+      assert.strictEqual(1442707200000, solarCalc.dusk.getTime());
     });
 
     it('get nautical dusk', function() {
-      assert.equal(1444003200000, solarCalc.nauticalDusk.getTime());
+      assert.strictEqual(1444003200000, solarCalc.nauticalDusk.getTime());
     });
 
     it('get night start', function() {
-      assert.equal(1445385600000, solarCalc.nightStart.getTime());
+      assert.strictEqual(1445385600000, solarCalc.nightStart.getTime());
     });
 
     it('should get moon illuminosity', function() {
-      assert.equal(22, Math.round(solarCalc.lunarIlluminosity * 100));
+      assert.strictEqual(22, Math.round(solarCalc.lunarIlluminosity * 100));
     });
 
     it('should get moon distance', function() {
-      assert.equal(378178, solarCalc.lunarDistance);
+      assert.strictEqual(378178, solarCalc.lunarDistance);
     });
   });
 


### PR DESCRIPTION
This PR fixes a defect in the `getJD()` function in `sun.js`. Without this fix, every January and February the solar calculations are off by a few minutes.